### PR TITLE
Added shortcuts to makefile for label-filter and parallel runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ dm:
 
 # Run container tests
 .PHONY: container
-conatiner:
+container:
 	${GINKGO_RUN} --label-filter='container' .
 
 .PHONY: .version

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,13 @@
+# Run in parallel with P number of processes (workflows) at a time
+# To run all the simple tests, 2 at a time:
+# 	$ P=2 make simple
+ifdef P
+PARALLEL_OPT:=-procs=${P}
+endif
+
+# Base command to start the tests with ginkgo
+GINKGO_RUN?=ginkgo run ${PARALLEL_OPT} --v
+
 all: fmt vet
 
 .PHONY: fmt
@@ -8,9 +18,35 @@ fmt:
 vet:
 	go vet ./...
 
-.PHONY: int-test
-int-test:
-	ginkgo run -p --vv ./...
+# TODO: would be nice to tie this to a script that also deletes all the workflows and makes sure nothing is left over
+.PHONY: clean
+clean:
+	kubectl delete namespace nnf-system-needs-triage --ignore-not-found
+
+# Run all the tests
+.PHONY: test
+test:
+	${GINKGO_RUN} .
+
+# Run one test to ensure system is in working order
+.PHONY: sanity
+sanity:
+	${GINKGO_RUN} --label-filter='simple && xfs' .
+
+# Test all 4 filesytems
+.PHONY: simple
+simple:
+	${GINKGO_RUN} --label-filter='simple' .
+
+# Run Data Movement Tests (i.e. copy_in/copy_out). This does not test copy offload API.
+.PHONY: dm
+dm:
+	${GINKGO_RUN} --label-filter='dm' .
+
+# Run container tests
+.PHONY: container
+conatiner:
+	${GINKGO_RUN} --label-filter='container' .
 
 .PHONY: .version
 .version: ## Uses the git-version-gen script to generate a tag version

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,6 @@ github.com/NearNodeFlash/nnf-dm v0.0.6 h1:7vtZ1OQ6q99d+e3D65UVJYDpgOfTnKCN5o2sH6
 github.com/NearNodeFlash/nnf-dm v0.0.6/go.mod h1:uA52kTzehOnfP6ZsPQUKBG7NnpMmnApQoTyPFZuLy0U=
 github.com/NearNodeFlash/nnf-ec v0.0.0-20231010162453-a8168bb6a52f h1:aWtSSQLLk9mUZj94mowirQeVw9saf80gVe10X0rZe8o=
 github.com/NearNodeFlash/nnf-ec v0.0.0-20231010162453-a8168bb6a52f/go.mod h1:oxdwMqfttOF9dabJhqrWlirCnMk8/8eyLMwl+hducjk=
-github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240102213605-eedc75e58629 h1:09tEohKUT2xTiiOQBpwgns2n5dmCi2v6nUfhYbk2Z1s=
-github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240102213605-eedc75e58629/go.mod h1:oFhWJ/p05VdmEspOjMLMnue6XxkoY/w1HD1c9EhHJS8=
 github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240104015314-62f9e6fbdc51 h1:ksIYFKV32Gsx6Nyz/8JHpNQBPuyEx+IcP3QUIMp9jPw=
 github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240104015314-62f9e6fbdc51/go.mod h1:oFhWJ/p05VdmEspOjMLMnue6XxkoY/w1HD1c9EhHJS8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=

--- a/int_test.go
+++ b/int_test.go
@@ -54,11 +54,6 @@ var tests = []*T{
 	MakeTest("Lustre", "#DW jobdw type=lustre name=lustre capacity=50GB").WithLabels(Simple),
 	MakeTest("Raw", "#DW jobdw type=raw name=raw capacity=50GB").WithLabels(Simple),
 
-	// DuplicateTest(
-	// 	MakeTest("XFS", "#DW jobdw type=xfs name=xfs capacity=50GB").Pending(), // Will fail for Setup() exceeding time limit; needs investigation
-	// 	5,
-	// ),
-
 	// Storage Profiles
 	MakeTest("XFS with Storage Profile",
 		"#DW jobdw type=xfs name=xfs-storage-profile capacity=50GB profile=my-xfs-storage-profile").
@@ -81,6 +76,7 @@ var tests = []*T{
 		WithPersistentLustre("xfs-data-movement-lustre-instance").
 		WithGlobalLustreFromPersistentLustre("zenith", []string{"default"}).
 		WithPermissions(1050, 1051).
+		WithLabels("dm").
 		HardwareRequired(),
 	MakeTest("GFS2 with Data Movement",
 		"#DW jobdw type=gfs2 name=gfs2-data-movement capacity=50GB",
@@ -89,6 +85,7 @@ var tests = []*T{
 		WithPersistentLustre("gfs2-data-movement-lustre-instance").
 		WithGlobalLustreFromPersistentLustre("kelso", []string{"default"}).
 		WithPermissions(1050, 1051).
+		WithLabels("dm").
 		HardwareRequired(),
 	// PENDING: Having two lustres in a single test case doesn't work currently until we fix MGS conflict in int-test
 	MakeTest("Lustre with Data Movement",
@@ -98,6 +95,7 @@ var tests = []*T{
 		WithPersistentLustre("lustre-data-movement-lustre-instance").
 		WithGlobalLustreFromPersistentLustre("flame", []string{"default"}).
 		WithPermissions(1050, 1051).
+		WithLabels("dm").
 		HardwareRequired().Pending(),
 
 	// Containers - MPI

--- a/internal/options.go
+++ b/internal/options.go
@@ -86,7 +86,7 @@ func (t *T) WithStorageProfile() *T {
 		if args["command"] == "jobdw" || args["command"] == "create_persistent" {
 			if name, found := args["profile"]; found {
 				t.options.storageProfile = &TStorageProfile{name: name}
-				return t.WithLabels("storage_profile")
+				return t.WithLabels("storage_profile", "storage-profile")
 			}
 		}
 	}
@@ -128,7 +128,7 @@ func (t *T) WithContainerProfile(base string, options *ContainerProfileOptions) 
 		if args["command"] == "container" {
 			if profile, found := args["profile"]; found {
 				t.options.containerProfile = &TContainerProfile{name: profile, base: base, options: options}
-				return t.WithLabels("container_profile")
+				return t.WithLabels("container_profile", "container-profile")
 			}
 		}
 	}
@@ -182,7 +182,7 @@ type TMgsPool struct {
 
 func (t *T) WithMgsPool(name string, count int) *T {
 	t.options.mgsPool = &TMgsPool{name: name, count: count}
-	return t.WithLabels("mgsPool")
+	return t.WithLabels("mgs_pool", "mgs-pool")
 }
 
 type TGlobalLustre struct {
@@ -238,7 +238,7 @@ func (t *T) WithGlobalLustreFromPersistentLustre(name string, namespaces []strin
 		}
 	}
 
-	return t.WithLabels("global_lustre")
+	return t.WithLabels("global_lustre", "global-lustre")
 }
 
 type TDuplicate struct {


### PR DESCRIPTION
* Added Makefile targets for common test scenarios using label-filter
* Added an easy way to customize parallelism with `P` environment variable
* Removed some duplication with the ginkgo command
* For multi-word labels (e.g. storage profile), you can use either `_` or `-` as the separator.

This allows you to do things like run the simple tests in parallel, 2 workflows at a time:

```
P=2 make simple
```

Or run the full suite, 8 workflows at a time:

```
P=8 make test
```