### PR TITLE
Fix nnf-dm module issue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 
 require (
 	github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20231115220321-eb84599f9630
-	github.com/NearNodeFlash/nnf-dm v0.0.1-0.20231221175134-0328a9ef0750
 	github.com/NearNodeFlash/nnf-ec v0.0.0-20231010162453-a8168bb6a52f // indirect
 	github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240104015314-62f9e6fbdc51
 )

--- a/go.sum
+++ b/go.sum
@@ -2,10 +2,6 @@ github.com/DataWorkflowServices/dws v0.0.1-0.20240102213032-8d38db39e6c6 h1:xGf+
 github.com/DataWorkflowServices/dws v0.0.1-0.20240102213032-8d38db39e6c6/go.mod h1:grHFCu0CoUK8exzS57r6cdf4qHpG1Pv5nl0n7evpaUM=
 github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20231115220321-eb84599f9630 h1:kgOtvQWxWb/EgbYcvzoEajVB6Af365KokNVKl1NmnFM=
 github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20231115220321-eb84599f9630/go.mod h1:qBcz9p8sXm1qhDf8WUmhxTlD1NCMEjoAD7NoHbQvMiI=
-github.com/NearNodeFlash/nnf-dm v0.0.1-0.20231221175134-0328a9ef0750 h1:UxE+FJsMN4oCkwSG47P81wAWIYGUY1XGfLna9mVrykg=
-github.com/NearNodeFlash/nnf-dm v0.0.1-0.20231221175134-0328a9ef0750/go.mod h1:2Erg8XbSCW711CNEPFmkTADxk3ZXl1aJXCRwXyE/Qfk=
-github.com/NearNodeFlash/nnf-dm v0.0.6 h1:7vtZ1OQ6q99d+e3D65UVJYDpgOfTnKCN5o2sH6xQcr0=
-github.com/NearNodeFlash/nnf-dm v0.0.6/go.mod h1:uA52kTzehOnfP6ZsPQUKBG7NnpMmnApQoTyPFZuLy0U=
 github.com/NearNodeFlash/nnf-ec v0.0.0-20231010162453-a8168bb6a52f h1:aWtSSQLLk9mUZj94mowirQeVw9saf80gVe10X0rZe8o=
 github.com/NearNodeFlash/nnf-ec v0.0.0-20231010162453-a8168bb6a52f/go.mod h1:oxdwMqfttOF9dabJhqrWlirCnMk8/8eyLMwl+hducjk=
 github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240104015314-62f9e6fbdc51 h1:ksIYFKV32Gsx6Nyz/8JHpNQBPuyEx+IcP3QUIMp9jPw=

--- a/suite_test.go
+++ b/suite_test.go
@@ -41,7 +41,6 @@ import (
 
 	dwsv1alpha2 "github.com/DataWorkflowServices/dws/api/v1alpha2"
 	lusv1alpha1 "github.com/NearNodeFlash/lustre-fs-operator/api/v1alpha1"
-	dmv1alpha1 "github.com/NearNodeFlash/nnf-dm/api/v1alpha1"
 	nnfv1alpha1 "github.com/NearNodeFlash/nnf-sos/api/v1alpha1"
 )
 
@@ -86,9 +85,6 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	err = lusv1alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = dmv1alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = nnfv1alpha1.AddToScheme(scheme.Scheme)


### PR DESCRIPTION
nnf-dm no longer needs to be in the scheme due to the change to nnf-dm where the API was moved to nnf-sos a while back. This was causing `go mod tidy` to revert back to the previous release of nnf-dm since it still had the nnf-dm API.