### PR TITLE
Add slack notifications to NNF Integration-Test workflow

### DIFF
--- a/.github/workflows/int-test.yaml
+++ b/.github/workflows/int-test.yaml
@@ -43,6 +43,11 @@ on:
         type: string
         required: true
         default: "2m"
+      notifySlack:
+        description: Report start/results to slack
+        required: true
+        default: true
+        type: boolean
 env:
   TEST_TARGET: simple
   PROCS: 1
@@ -50,10 +55,40 @@ env:
   LTIMEOUT: 2m
   SYSTEM: htx-1
   ROUNDS: 1
+  SLACK_CHANNEL_ID: C043U7PRGGM
+  RUN_URL: "<https://github.com/NearNodeFlash/nnf-integration-test/actions/runs/${{ github.run_id }}|#${{ github.run_number }}>"
 jobs:
   int-test:
     runs-on: ${{ inputs.system || 'htx-1' }}
+    outputs:
+      test-result: ${{ steps.int-test.outcome }}
     steps:
+      - name: Start Slack Message
+        if: ${{ inputs.notifySlack }}
+        uses: archive/github-actions-slack@master
+        id: start-message
+        with:
+          slack-function: send-message
+          slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
+          slack-channel: ${{ env.SLACK_CHANNEL_ID }}
+          slack-optional-blocks: >-
+            [
+              {
+                "type": "header",
+                "text": {
+                  "type": "plain_text",
+                  "text": "NNF Integration Test",
+                  "emoji": true
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "Run ${{ env.RUN_URL }} started on ${{ runner.name }}\n_triggered via ${{ github.event_name }}_"
+                }
+              },
+            ]
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -95,6 +130,12 @@ jobs:
           GINKGO_CLI_VER=$(grep "github.com/onsi/ginkgo" go.mod | awk '{print $2}')
           bash -c 'go install github.com/onsi/ginkgo/v2/ginkgo@$GINKGO_CLI_VER'
       - name: Run int-test (P=${{ env.P }} ${{ env.TEST_TARGET }}) ${{ env.ROUNDS }} time(s) on ${{ env.SYSTEM }}
+        id: int-test
+        shell: bash
+        env:
+          P: ${{ env.PROCS }}
+          HTIMEOUT: ${{ env.HTIMEOUT }}
+          LTIMEOUT: ${{ env.LTIMEOUT }}
         run: |
           for i in {1..${{ env.ROUNDS }}}; do
             echo ""
@@ -109,8 +150,76 @@ jobs:
             echo "@@@@@@@@@@@@@@@@@@@@"
             echo ""
           done
-        shell: bash
-        env:
-          P: ${{ env.PROCS }}
-          HTIMEOUT: ${{ env.HTIMEOUT }}
-          LTIMEOUT: ${{ env.LTIMEOUT }}
+      - name: Failure Slack Message
+        if: ${{ inputs.notifySlack && failure() }}
+        uses: archive/github-actions-slack@master
+        with:
+          slack-function: update-message
+          slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
+          slack-channel: ${{ env.SLACK_CHANNEL_ID }}
+          slack-update-message-ts: ${{ fromJson(steps.start-message.outputs.slack-result).response.message.ts }}
+          slack-optional-blocks: >-
+            [
+              {
+                "type": "header",
+                "text": {
+                  "type": "plain_text",
+                  "text": "NNF Integration Test",
+                  "emoji": true
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "Run ${{ env.RUN_URL }} started on ${{ runner.name }}\n_triggered via ${{ github.event_name }}_"
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": ":red_circle: Test Failed"
+                }
+              },
+              {
+                "type": "divider"
+              }
+            ]
+
+      - name: Success Slack Message
+        if: ${{ inputs.notifySlack && success() }}
+        uses: archive/github-actions-slack@master
+        with:
+          slack-function: update-message
+          slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
+          slack-channel: ${{ env.SLACK_CHANNEL_ID }}
+          slack-update-message-ts: ${{ fromJson(steps.start-message.outputs.slack-result).response.message.ts }}
+          slack-optional-blocks: >-
+            [
+              {
+                "type": "header",
+                "text": {
+                  "type": "plain_text",
+                  "text": "NNF Integration Test",
+                  "emoji": true
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "Run ${{ env.RUN_URL }} started on ${{ runner.name }}\n_triggered via ${{ github.event_name }}_"
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": ":green_circle: Test Passed"
+                }
+              },
+              {
+                "type": "divider"
+              }
+            ]


### PR DESCRIPTION
Adds slack messages using the rabbit-notifications app that is registered for use on the Cray workspace.

This sends messages to the #rabbit-notifications channel when the workflow starts and updates the message with the result.

When starting the workflow manually, this functionality can be disabled to avoid spamming the channel.