### PR TITLE
Update copy-out.sh helper_image script to account for index mount directories

### DIFF
--- a/helper_image/scripts/copy-out.sh
+++ b/helper_image/scripts/copy-out.sh
@@ -41,6 +41,10 @@ fi
 if [[ ${NUM_COMPUTES} -gt 0 ]]; then
     echo "Checking for index mount directories"
 
+    # remove any escaping or quotes from the path
+    COPY_OUT=${COPY_OUT//\'/}
+    COPY_OUT=${COPY_OUT//\\/}
+
     # verify there are $NUM_COMPUTES directories/files
     LS_OUTPUT=$(/bin/ls -l ${COPY_OUT})
     if ! echo "${LS_OUTPUT}" | wc -l | grep "${NUM_COMPUTES}"; then

--- a/helper_image/scripts/copy-out.sh
+++ b/helper_image/scripts/copy-out.sh
@@ -9,11 +9,12 @@ function usage() {
     echo
     echo "Syntax: copy-out.sh FILE_IN FILE_OUT <NUM_COMPUTES>"
     echo
-    echo "Set <NUM_COMPUTES> to 0 when index mount directories are not expected"
+    echo "Set <NUM_COMPUTES> to 0 when index mount directories are not expected. When expected, the "
+    echo "path should include an asterik to represent the directories it needs to be escaped (\*)"
     echo
     echo "example:"
     echo "copy-out.sh /lus/global/testuser/test.in /lus/global/testuser/test.out 0"
-    echo "copy-out.sh /lus/global/testuser/test.in /lus/global/testuser/*/test.out 4"
+    echo "copy-out.sh /lus/global/testuser/test.in /lus/global/testuser/\*/test.out 4"
     echo
 }
 
@@ -41,7 +42,7 @@ if [[ ${NUM_COMPUTES} -gt 0 ]]; then
     echo "Checking for index mount directories"
 
     # verify there are $NUM_COMPUTES directories/files
-    LS_OUTPUT=$(/bin/ls -l "${COPY_OUT}")
+    LS_OUTPUT=$(/bin/ls -l ${COPY_OUT})
     if ! echo "${LS_OUTPUT}" | wc -l | grep "${NUM_COMPUTES}"; then
         echo "missing index directories, expected ${NUM_COMPUTES}:"
         /bin/ls -l "${COPY_OUT}"
@@ -52,7 +53,7 @@ if [[ ${NUM_COMPUTES} -gt 0 ]]; then
     echo "${COPY_IN}: ${COPY_IN_MD5SUM}"
 
     # make sure each checksum is the same
-    md5sum "${COPY_OUT}" | while read -r line; do
+    md5sum ${COPY_OUT} | while read -r line; do
         SUM=$(echo "${line}" | awk '{print $1}')
         FILE=$(echo "${line}" | awk '{print $2}')
         echo "${FILE}: ${SUM}"

--- a/helper_image/scripts/copy-out.sh
+++ b/helper_image/scripts/copy-out.sh
@@ -21,61 +21,61 @@ COPY_IN=$1
 COPY_OUT=$2
 NUM_COMPUTES=$3
 
-if [[ -z "$COPY_IN" ]]; then
+if [[ -z ${COPY_IN} ]]; then
     usage
     exit 1
-elif [[ -z "$COPY_OUT" ]]; then
+elif [[ -z ${COPY_OUT} ]]; then
     usage
     exit 1
-elif [[ -z "$NUM_COMPUTES" ]]; then
+elif [[ -z ${NUM_COMPUTES} ]]; then
     usage
     exit 1
 fi
 
-if [ ! -e "$COPY_IN" ]; then
-    echo "$COPY_IN does not exist"
+if [[ ! -e ${COPY_IN} ]]; then
+    echo "${COPY_IN} does not exist"
     exit 1
 fi
 
-if [[ $NUM_COMPUTES -gt 0 ]]; then
+if [[ ${NUM_COMPUTES} -gt 0 ]]; then
     echo "Checking for index mount directories"
 
     # verify there are $NUM_COMPUTES directories/files
-    LS_OUTPUT=$(/bin/ls -l $COPY_OUT)
-    if ! echo "$LS_OUTPUT" | wc -l | grep $NUM_COMPUTES; then
-        echo "missing index directories, expected $NUM_COMPUTES:"
-        /bin/ls -l $COPY_OUT
+    LS_OUTPUT=$(/bin/ls -l "${COPY_OUT}")
+    if ! echo "${LS_OUTPUT}" | wc -l | grep "${NUM_COMPUTES}"; then
+        echo "missing index directories, expected ${NUM_COMPUTES}:"
+        /bin/ls -l "${COPY_OUT}"
         exit 1
     fi
 
-    COPY_IN_MD5SUM=$(md5sum "$COPY_IN" | awk '{print $1}')
-    echo "$COPY_IN: $COPY_IN_MD5SUM"
+    COPY_IN_MD5SUM=$(md5sum "${COPY_IN}" | awk '{print $1}')
+    echo "${COPY_IN}: ${COPY_IN_MD5SUM}"
 
     # make sure each checksum is the same
-    md5sum $COPY_OUT | while read -r line; do
-        SUM=$(echo $line | awk '{print $1}')
-        FILE=$(echo $line | awk '{print $2}')
-        echo "$FILE: $SUM"
+    md5sum "${COPY_OUT}" | while read -r line; do
+        SUM=$(echo "${line}" | awk '{print $1}')
+        FILE=$(echo "${line}" | awk '{print $2}')
+        echo "${FILE}: ${SUM}"
 
-        if [ ! "$COPY_IN_MD5SUM" = "$SUM" ]; then
+        if [[ ! ${COPY_IN_MD5SUM} = "${SUM}" ]]; then
             echo "md5sums do not match"
             exit 1
         fi
     done
 else
     echo "Not checking for index mount directories"
-    if [ ! -e "$COPY_OUT" ]; then
-        echo "$COPY_OUT does not exist"
+    if [[ ! -e ${COPY_OUT} ]]; then
+        echo "${COPY_OUT} does not exist"
         exit 1
     fi
 
-    COPY_IN_MD5SUM=$(md5sum "$COPY_IN" | awk '{print $1}')
-    COPY_OUT_MD5SUM=$(md5sum "$COPY_OUT" | awk '{print $1}')
+    COPY_IN_MD5SUM=$(md5sum "${COPY_IN}" | awk '{print $1}')
+    COPY_OUT_MD5SUM=$(md5sum "${COPY_OUT}" | awk '{print $1}')
 
-    echo "$COPY_IN: $COPY_IN_MD5SUM"
-    echo "$COPY_OUT: $COPY_OUT_MD5SUM"
+    echo "${COPY_IN}: ${COPY_IN_MD5SUM}"
+    echo "${COPY_OUT}: ${COPY_OUT_MD5SUM}"
 
-    if [ "$COPY_IN_MD5SUM" = "$COPY_OUT_MD5SUM" ]; then
+    if [[ ${COPY_IN_MD5SUM} = "${COPY_OUT_MD5SUM}" ]]; then
         echo "md5sums match"
         exit 0
     else

--- a/helper_image/scripts/copy-out.sh
+++ b/helper_image/scripts/copy-out.sh
@@ -1,24 +1,33 @@
 #!/bin/bash
 
+set -e
+
 function usage() {
     echo
     echo "Verify the md5sums of two files match"
     echo "This is used after copy_out directives to ensure the copy_in file matches the copy_out file"
     echo
-    echo "Syntax: copy-out.sh FILE_IN FILE_OUT"
+    echo "Syntax: copy-out.sh FILE_IN FILE_OUT <NUM_COMPUTES>"
+    echo
+    echo "Set <NUM_COMPUTES> to 0 when index mount directories are not expected"
     echo
     echo "example:"
-    echo "copy-out.sh /lus/global/testuser/test.in /lus/global/testuser/test.out"
+    echo "copy-out.sh /lus/global/testuser/test.in /lus/global/testuser/test.out 0"
+    echo "copy-out.sh /lus/global/testuser/test.in /lus/global/testuser/*/test.out 4"
     echo
 }
 
 COPY_IN=$1
 COPY_OUT=$2
+NUM_COMPUTES=$3
 
 if [[ -z "$COPY_IN" ]]; then
     usage
     exit 1
 elif [[ -z "$COPY_OUT" ]]; then
+    usage
+    exit 1
+elif [[ -z "$NUM_COMPUTES" ]]; then
     usage
     exit 1
 fi
@@ -28,21 +37,49 @@ if [ ! -e "$COPY_IN" ]; then
     exit 1
 fi
 
-if [ ! -e "$COPY_OUT" ]; then
-    echo "$COPY_OUT does not exist"
-    exit 1
-fi
+if [[ $NUM_COMPUTES -gt 0 ]]; then
+    echo "Checking for index mount directories"
 
-COPY_IN_MD5SUM=$(md5sum "$COPY_IN" | awk '{print $1}')
-COPY_OUT_MD5SUM=$(md5sum "$COPY_OUT" | awk '{print $1}')
+    # verify there are $NUM_COMPUTES directories/files
+    LS_OUTPUT=$(/bin/ls -l $COPY_OUT)
+    if ! echo "$LS_OUTPUT" | wc -l | grep $NUM_COMPUTES; then
+        echo "missing index directories, expected $NUM_COMPUTES:"
+        /bin/ls -l $COPY_OUT
+        exit 1
+    fi
 
-echo "$COPY_IN: $COPY_IN_MD5SUM"
-echo "$COPY_OUT: $COPY_OUT_MD5SUM"
+    COPY_IN_MD5SUM=$(md5sum "$COPY_IN" | awk '{print $1}')
+    echo "$COPY_IN: $COPY_IN_MD5SUM"
 
-if [ "$COPY_IN_MD5SUM" = "$COPY_OUT_MD5SUM" ]; then
-    echo "md5sums match"
-    exit 0
+    # make sure each checksum is the same
+    md5sum $COPY_OUT | while read -r line; do
+        SUM=$(echo $line | awk '{print $1}')
+        FILE=$(echo $line | awk '{print $2}')
+        echo "$FILE: $SUM"
+
+        if [ ! "$COPY_IN_MD5SUM" = "$SUM" ]; then
+            echo "md5sums do not match"
+            exit 1
+        fi
+    done
 else
-    echo "md5sums do not match"
-    exit 1
+    echo "Not checking for index mount directories"
+    if [ ! -e "$COPY_OUT" ]; then
+        echo "$COPY_OUT does not exist"
+        exit 1
+    fi
+
+    COPY_IN_MD5SUM=$(md5sum "$COPY_IN" | awk '{print $1}')
+    COPY_OUT_MD5SUM=$(md5sum "$COPY_OUT" | awk '{print $1}')
+
+    echo "$COPY_IN: $COPY_IN_MD5SUM"
+    echo "$COPY_OUT: $COPY_OUT_MD5SUM"
+
+    if [ "$COPY_IN_MD5SUM" = "$COPY_OUT_MD5SUM" ]; then
+        echo "md5sums match"
+        exit 0
+    else
+        echo "md5sums do not match"
+        exit 1
+    fi
 fi

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -82,6 +82,9 @@ type T struct {
 	// Helper pods that run during a test to do extra work (e.g. data
 	// movement). These need to be cleaned up and tracked.
 	helperPods []*corev1.Pod
+
+	// Compute nodes that were assigned to the test. This is determined at test runtime.
+	computes *dwsv1alpha2.Computes
 }
 
 func MakeTest(name string, directives ...string) *T {

--- a/internal/states.go
+++ b/internal/states.go
@@ -95,6 +95,9 @@ func (t *T) setup(ctx context.Context, k8sClient client.Client, workflow *dwsv1a
 		}
 
 		Expect(k8sClient.Update(ctx, computes)).To(Succeed())
+
+		// Assign these for use elsewhere
+		t.computes = computes
 	}
 
 	By("Assigns Servers")

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -74,6 +74,7 @@ func VerifyCopyOut(ctx context.Context, k8sClient client.Client, t *T, o TOption
 	numComputes := "0"
 	if strings.Contains(lus.out, "*/") {
 		numComputes = strconv.Itoa(len(t.computes.Data))
+		lus.out = strings.ReplaceAll(lus.out, "*", "\\*") // escape the asterisk so bash doesn't glob
 	}
 
 	By("Starting copy-out pod and verifying copy out")

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 
@@ -68,10 +69,18 @@ func SetupCopyIn(ctx context.Context, k8sClient client.Client, t *T, o TOptions)
 func VerifyCopyOut(ctx context.Context, k8sClient client.Client, t *T, o TOptions) {
 	lus := t.options.globalLustre
 
+	// Set numComputes to the number of compute nodes if index mount directories are expected.
+	// Otherwise use 0 for lustre-lustre.
+	numComputes := "0"
+	if strings.Contains(lus.out, "*/") {
+		numComputes = strconv.Itoa(len(t.computes.Data))
+	}
+
 	By("Starting copy-out pod and verifying copy out")
 	runHelperPod(ctx, k8sClient, t, "copy-out", "/copy-out.sh", []string{
 		lus.in,
 		lus.out,
+		numComputes,
 	})
 }
 


### PR DESCRIPTION
- Updated copy-out.sh helper script to take in the number of compute
  nodes to verify index mount directories
- This also signals if index mount directories are verified or not
  (NUM_COMPUTES > 0)
- Added t.computes to store the compute nodes used for the test. This is
  used to get the length to give to copy-out.sh for NUM_COMPUTES
- Adjust the dest path to give to copy-out.sh to include `*/` for index
  mount directories

Signed-off-by: Blake Devcich <blake.devcich@hpe.com>
