### PR TITLE
Add workflow for dm-system-test

### DIFF
--- a/.github/workflows/int-test.yaml
+++ b/.github/workflows/int-test.yaml
@@ -337,3 +337,20 @@ jobs:
                 "type": "divider"
               }
             ]
+  dm-system-test:
+    needs: int-test
+    if: ${{ github.event_name == 'schedule' }}
+    runs-on: ${{ inputs.system || 'htx-1' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Version
+        run: ./git-version-gen
+      - name: Whoami
+        run: id
+      - name: Run dm-system-test
+        run: |
+          cd dm-system-test
+          make all

--- a/dm-system-test/copy-in-copy-out/copy-in-copy-out.bats
+++ b/dm-system-test/copy-in-copy-out/copy-in-copy-out.bats
@@ -23,8 +23,6 @@
 # table is then converted to json, which is used for this test. `convert_table.py` is used to perform
 # that converstion into `copy-in-copy-out.json`, which is used by this file.
 
-# number of computes
-N=4
 
 # source the files by doing a copy_in
 # the source files are created with `create-testfiles.sh`
@@ -38,6 +36,11 @@ num_tests=$(jq length $tests_file)
 
 # Default to gfs2, but allow FS_TYPE env var to override
 fs_type="${FS_TYPE:-gfs2}"
+
+# Number of compute nodes; default to 4
+if [[ -z N ]]; then
+    N=4
+fi
 
 # Provide a way to run sanity or a protion of the tests (e.g. NUM_TESTS=1)
 if [[ -v NUM_TESTS ]]; then


### PR DESCRIPTION
This adds a workflow to run the dm-system-test if the int-test is sucessful. It only does this via a scheduled run (cron) and not if you trigger via the web UI (workflow_dispatch).