### PR TITLE
El Cap updates: flux --requires and dm updates

### DIFF
--- a/system-test/Makefile
+++ b/system-test/Makefile
@@ -28,6 +28,9 @@ GLOBAL_LUSTRE_ROOT ?= /lus/global
 # Default to no flux queue
 Q ?=
 
+# No specfic nodes (with flux --requires)
+R ?=
+
 # Default bats command
 BATS = bats -j $(J)
 

--- a/system-test/README.md
+++ b/system-test/README.md
@@ -45,6 +45,8 @@ the command line or changed in the `Makefile`.
 
 - `N`: Number of compute nodes to request via `flux -N`
 - `J`: Number of parallel tests to run via `bats -j`
+- `Q`: Which flux queue to use to submit the job via `flux -q`
+- `R`: Use `flux --requires=hosts[R]` to pass hosts constraint
 - `GLOBAL_LUSTRE_ROOT`: For tests that require global lustre, this is the file system path where
 user directories are located (e.g. `/lus/global/myuser`)
 

--- a/system-test/dm/copy-in-copy-out/create-testfiles.sh
+++ b/system-test/dm/copy-in-copy-out/create-testfiles.sh
@@ -37,7 +37,7 @@ cp ${TESTDIR}/src/job/data.out ${TESTDIR}/src/job2/data2.out
 mkdir -p ${TESTDIR}/dest
 
 # let the users group own testdir
-chown -R ${USER}:users ${TESTDIR}
+#chown -R ${USER}:users ${TESTDIR}
 
 # make sure src isn't group writeable though (to protect it)
 chmod -R g-w ${TESTDIR}/src

--- a/system-test/dm/test-copy-in-copy-out.sh
+++ b/system-test/dm/test-copy-in-copy-out.sh
@@ -36,13 +36,17 @@ pushd copy-in-copy-out
 # turn markdown table into json
 python3 convert_table.py copy-in-copy-out.md copy-in-copy-out.json
 
-# Run copy_out tests for each filesystem
-FS_TYPE=gfs2 ./copy-in-copy-out.bats
-FS_TYPE=xfs ./copy-in-copy-out.bats
-FS_TYPE=lustre ./copy-in-copy-out.bats
+if [[ -n "${FS_TYPE}" ]]; then
+    ./copy-in-copy-out.bats
+else
+    # Run copy_out tests for each filesystem
+    FS_TYPE=gfs2 ./copy-in-copy-out.bats
+    FS_TYPE=xfs ./copy-in-copy-out.bats
+    FS_TYPE=lustre ./copy-in-copy-out.bats
 
-# Run the same with copy offload with supported filesystems (gfs2->lustre, lustre->lustre)
-FS_TYPE=gfs2 COPY_OFFLOAD=y ./copy-in-copy-out.bats
-FS_TYPE=lustre COPY_OFFLOAD=y ./copy-in-copy-out.bats
+    # Run the same with copy offload with supported filesystems (gfs2->lustre, lustre->lustre)
+    FS_TYPE=gfs2 COPY_OFFLOAD=y ./copy-in-copy-out.bats
+    FS_TYPE=lustre COPY_OFFLOAD=y ./copy-in-copy-out.bats
+fi
 
 popd

--- a/system-test/system-test.bats
+++ b/system-test/system-test.bats
@@ -28,9 +28,6 @@ if [[ -z "${N}" ]]; then
     N=4
 fi
 
-# Command to run on the compute node via flux
-COMPUTE_CMD='bash -c "hostname"'
-
 # Flux command
 FLUX="flux run -l -N${N} --wait-event=clean"
 
@@ -38,6 +35,17 @@ FLUX="flux run -l -N${N} --wait-event=clean"
 if [ "${Q}" != "" ]; then
     FLUX+=" -q ${Q}"
 fi
+
+# Require specific rabbits
+if [ "${R}" != "" ]; then
+    FLUX+=" --requires=hosts:${R}"
+fi
+
+# Command to run on the compute node via flux
+# TODO try set -x
+COMPUTE_CMD='hostname'
+
+echo ${FLUX}
 
 #----------------------------------------------------------
 # Simple Tests
@@ -163,7 +171,7 @@ fi
         #DW jobdw type=gfs2 name=containers-gfs2-global-lustre capacity=100GB \
         #DW container name=containers-gfs2-global-lustre profile=example-success \
             DW_JOB_foo_local_storage=containers-gfs2-global-lustre \
-			DW_GLOBAL_foo_global_lustre=${GLOBAL_LUSTRE_ROOT}" \
+            DW_GLOBAL_foo_global_lustre=${GLOBAL_LUSTRE_ROOT}" \
         ${COMPUTE_CMD}
 }
 
@@ -173,7 +181,7 @@ fi
         #DW jobdw type=gfs2 name=containers-gfs2-global-lustre-mpi capacity=100GB \
         #DW container name=containers-gfs2-global-lustre-mpi profile=example-mpi \
             DW_JOB_foo_local_storage=containers-gfs2-global-lustre-mpi \
-			DW_GLOBAL_foo_global_lustre=${GLOBAL_LUSTRE_ROOT}" \
+            DW_GLOBAL_foo_global_lustre=${GLOBAL_LUSTRE_ROOT}" \
         ${COMPUTE_CMD}
 }
 
@@ -183,7 +191,7 @@ fi
         #DW jobdw type=lustre name=containers-lustre-global-lustre capacity=100GB \
         #DW container name=containers-lustre-global-lustre profile=example-success \
             DW_JOB_foo_local_storage=containers-lustre-global-lustre \
-			DW_GLOBAL_foo_global_lustre=${GLOBAL_LUSTRE_ROOT}" \
+            DW_GLOBAL_foo_global_lustre=${GLOBAL_LUSTRE_ROOT}" \
         ${COMPUTE_CMD}
 }
 
@@ -193,7 +201,7 @@ fi
         #DW jobdw type=lustre name=containers-lustre-global-lustre-mpi capacity=100GB \
         #DW container name=containers-lustre-global-lustre-mpi profile=example-mpi \
             DW_JOB_foo_local_storage=containers-lustre-global-lustre-mpi \
-			DW_GLOBAL_foo_global_lustre=${GLOBAL_LUSTRE_ROOT}" \
+            DW_GLOBAL_foo_global_lustre=${GLOBAL_LUSTRE_ROOT}" \
         ${COMPUTE_CMD}
 }
 


### PR DESCRIPTION
- Added R environment variable to pass hosts to `flux --requires=hosts:` to target specific compute nodes
- DM test now uses -q and --requires
- Fixed testdir permissions
- make dm now acknowledges FS_TYPE env var
- COMPUTE_CMD is now just using `hostname` (until addressed)