### PR TITLE
Add unique names for persistent tests

### DIFF
--- a/system-test/Makefile
+++ b/system-test/Makefile
@@ -48,7 +48,7 @@ export R
 export PATH := $(shell ./bats_env.sh):$(PATH)
 
 # Default bats command
-BATS = bats -j $(J)
+BATS = bats -j $(J) -T
 
 .PHONY: all
 all: init test dm


### PR DESCRIPTION
- Added short UUIDs to persistent filesystems to allow multiple users to run system-test
- Added persistent usage tests for all filesystems, but only lustre can be used due a flux scheduling issue
	- Non-lustre tests are skipped for now

Signed-off-by: Blake Devcich <blake.devcich@hpe.com>
