### PR TITLE
system-test: Add env file to specify GLOBAL_LUSTRE_ROOT

### DIFF
--- a/.github/workflows/int-test.yaml
+++ b/.github/workflows/int-test.yaml
@@ -360,6 +360,13 @@ jobs:
         run: |
           cd system-test
           make init
+      - name: Create env file
+        run: |
+          cd system-test
+          touch env
+          echo "GLOBAL_LUSTRE_ROOT?=/lus/global" >> env
+          echo "N ?=4" >> env
+          echo "J ?=1" >> env
       - name: Run system-test
         run: |
           cd system-test
@@ -384,6 +391,13 @@ jobs:
         run: |
           cd system-test
           make init
+      - name: Create env file
+        run: |
+          cd system-test
+          touch env
+          echo "GLOBAL_LUSTRE_ROOT?=/lus/global" >> env
+          echo "N ?=4" >> env
+          echo "J ?=1" >> env
       - name: Run dm-system-test
         run: |
           cd system-test


### PR DESCRIPTION
The logic to find the first lustre filesystem does not work for hpe
systems since `/lus/global` is not the first lustre filesystem on these
systems.

That is ok, we can use the `env` to make sure we're using the correct
`GLOBAL_LUSTRE_ROOT`.

Signed-off-by: Blake Devcich <blake.devcich@hpe.com>
