### PR TITLE
dm-system-test: Make it parallel

### DIFF
--- a/.github/workflows/int-test.yaml
+++ b/.github/workflows/int-test.yaml
@@ -396,8 +396,8 @@ jobs:
           cd system-test
           touch env
           echo "GLOBAL_LUSTRE_ROOT?=/lus/global" >> env
-          echo "N ?=4" >> env
-          echo "J ?=1" >> env
+          echo "N ?=2" >> env
+          echo "J ?=2" >> env
       - name: Run dm-system-test
         run: |
           cd system-test

--- a/system-test/dm/copy-in-copy-out/copy-in-copy-out.bats
+++ b/system-test/dm/copy-in-copy-out/copy-in-copy-out.bats
@@ -71,14 +71,17 @@ for ((i = 0; i < NUM_TESTS; i++)); do
 done
 
 function setup() {
-    ./create-testfiles.sh ${TESTDIR}
-    rm -rf ${TESTDIR}/dest/*
+    # Make a unique directory to support simulteanous tests
+    export UUID=$(uuidgen | cut -d'-' -f1)
+    export DESTDIR=${TESTDIR}/${UUID}
+    mkdir ${DESTDIR}
+    ./create-testfiles.sh ${DESTDIR}
 }
 
 function teardown() {
     # clean up if it succeeded, otherwise leave it around for inspection (if no other tests run afterwards)
-    if [[ -v "${BATS_TEST_COMPLETED}" ]]; then
-        rm -rf ${TESTDIR}/dest/*
+    if [[ "${BATS_TEST_COMPLETED}" -eq 1 ]]; then
+        rm -rf ${DESTDIR}
     fi
 }
 
@@ -88,9 +91,9 @@ function test_copy_in_copy_out() {
     local dest=$(cat $tests_file | jq -r ".[$idx].dest")
     local expected=$(cat $tests_file | jq -r ".[$idx].expected")
 
-    local copy_in_src=${TESTDIR}/src/
+    local copy_in_src=${DESTDIR}/src/
 
-    # expand the $TESTDIR variable in dest/expected vars
+    # expand the $DESTDIR variable in dest/expected vars
     dest="$(eval echo "$dest")"
     expected="$(eval echo "$expected")"
 

--- a/system-test/dm/copy-in-copy-out/copy-in-copy-out.md
+++ b/system-test/dm/copy-in-copy-out/copy-in-copy-out.md
@@ -1,31 +1,31 @@
 | test   | src                              | srcType | dest                                       | destType   | expected                                             |
 | ------ | -------------------------------- | ------- | ------------------------------------------ | ---------- | ---------------------------------------------------- |
-| file1  | $DW_JOB_copyout-test/job/data.out     | file    | $TESTDIR/dest                          | dir        | $TESTDIR/dest/*/data.out                         |
-| file2  | $DW_JOB_copyout-test/job/data.out     | file    | $TESTDIR/dest/                         | dir/       | $TESTDIR/dest/*/data.out                         |
-| file2a | $DW_JOB_copyout-test/job/data.out     | file    | $TESTDIR/dest/data.out                 | file       | $TESTDIR/dest/*/data.out                         |
-| file3  | $DW_JOB_copyout-test/job/data.out     | file    | $TESTDIR/dest/component                | DNE - file | $TESTDIR/dest/*/component                        |
-| file4  | $DW_JOB_copyout-test/job/data.out     | file    | $TESTDIR/dest/newdir/                  | DNE - dir/ | $TESTDIR/dest/newdir/*/data.out                  |
-| file5  | $DW_JOB_copyout-test/job/data.out     | file    | $TESTDIR/dest/newdir/component         | DNE - file | $TESTDIR/dest/newdir/*/component                 |
-| file6  | $DW_JOB_copyout-test/job/data.out     | file    | $TESTDIR/dest/newdir/newdir2/          | DNE - dir/ | $TESTDIR/dest/newdir/newdir2/*/data.out          |
-| file7  | $DW_JOB_copyout-test/job/data.out     | file    | $TESTDIR/dest/newdir/newdir2/component | DNE - file | $TESTDIR/dest/newdir/newdir2/*/component         |
-| dir1   | $DW_JOB_copyout-test/job              | dir     | $TESTDIR/dest                          | dir        | $TESTDIR/dest/*/job/data.out                     |
-| dir2   | $DW_JOB_copyout-test/job/job2         | dir     | $TESTDIR/dest                          | dir        | $TESTDIR/dest/*/job2/data3.out                   |
-| dir3   | $DW_JOB_copyout-test/job              | dir     | $TESTDIR/dest/                         | dir/       | $TESTDIR/dest/*/job/data.out                     |
-| dir4   | $DW_JOB_copyout-test/job/             | dir/    | $TESTDIR/dest                          | dir        | $TESTDIR/dest/*/data.out                         |
-| dir5   | $DW_JOB_copyout-test/job/             | dir/    | $TESTDIR/dest/                         | dir/       | $TESTDIR/dest/*/data.out                         |
-| dir6   | $DW_JOB_copyout-test/job              | dir     | $TESTDIR/dest/newdir                   | DNE - dir  | $TESTDIR/dest/newdir/*/job/data.out              |
-| dir7   | $DW_JOB_copyout-test/job              | dir     | $TESTDIR/dest/newdir/                  | DNE - dir/ | $TESTDIR/dest/newdir/*/job/data.out              |
-| dir8   | $DW_JOB_copyout-test/job/             | dir/    | $TESTDIR/dest/newdir                   | DNE - dir  | $TESTDIR/dest/newdir/*/data.out                  |
-| dir9   | $DW_JOB_copyout-test/job/             | dir/    | $TESTDIR/dest/newdir/                  | DNE - dir/ | $TESTDIR/dest/newdir/*/data.out                  |
-| dir10  | $DW_JOB_copyout-test/job              | dir     | $TESTDIR/dest/newdir/newdir2           | DNE - dir  | $TESTDIR/dest/newdir/newdir2/*/job/data.out      |
-| dir11  | $DW_JOB_copyout-test/job              | dir     | $TESTDIR/dest/newdir/newdir2/          | DNE - dir/ | $TESTDIR/dest/newdir/newdir2/*/job/data.out      |
-| dir12  | $DW_JOB_copyout-test/job/             | dir/    | $TESTDIR/dest/newdir/newdir2           | DNE - dir  | $TESTDIR/dest/newdir/newdir2/*/data.out          |
-| dir13  | $DW_JOB_copyout-test/job/             | dir/    | $TESTDIR/dest/newdir/newdir2/          | DNE - dir/ | $TESTDIR/dest/newdir/newdir2/*/data.out          |
-| root1  | $DW_JOB_copyout-test                  | dir     | $TESTDIR/dest                          | dir        | $TESTDIR/dest/*/job/data.out                     |
-| root2  | $DW_JOB_copyout-test                  | dir     | $TESTDIR/dest/                         | dir/       | $TESTDIR/dest/*/job/data.out                     |
-| root3  | $DW_JOB_copyout-test/                 | dir/    | $TESTDIR/dest                          | dir        | $TESTDIR/dest/*/job/data.out                     |
-| root4  | $DW_JOB_copyout-test/                 | dir/    | $TESTDIR/dest/                         | dir/       | $TESTDIR/dest/*/job/data.out                     |
-| root5  | $DW_JOB_copyout-test                  | dir     | $TESTDIR/dest/newdir                   | dir        | $TESTDIR/dest/newdir/*/job/data.out              |
-| root6  | $DW_JOB_copyout-test                  | dir     | $TESTDIR/dest/newdir/                  | dir/       | $TESTDIR/dest/newdir/*/job/data.out              |
-| root7  | $DW_JOB_copyout-test/                 | dir/    | $TESTDIR/dest/newdir                   | dir        | $TESTDIR/dest/newdir/*/job/data.out              |
-| root8  | $DW_JOB_copyout-test/                 | dir/    | $TESTDIR/dest/newdir/                  | dir/       | $TESTDIR/dest/newdir/*/job/data.out              |
+| file1  | $DW_JOB_copyout-test/job/data.out     | file    | $DESTDIR/dest                          | dir        | $DESTDIR/dest/*/data.out                         |
+| file2  | $DW_JOB_copyout-test/job/data.out     | file    | $DESTDIR/dest/                         | dir/       | $DESTDIR/dest/*/data.out                         |
+| file2a | $DW_JOB_copyout-test/job/data.out     | file    | $DESTDIR/dest/data.out                 | file       | $DESTDIR/dest/*/data.out                         |
+| file3  | $DW_JOB_copyout-test/job/data.out     | file    | $DESTDIR/dest/component                | DNE - file | $DESTDIR/dest/*/component                        |
+| file4  | $DW_JOB_copyout-test/job/data.out     | file    | $DESTDIR/dest/newdir/                  | DNE - dir/ | $DESTDIR/dest/newdir/*/data.out                  |
+| file5  | $DW_JOB_copyout-test/job/data.out     | file    | $DESTDIR/dest/newdir/component         | DNE - file | $DESTDIR/dest/newdir/*/component                 |
+| file6  | $DW_JOB_copyout-test/job/data.out     | file    | $DESTDIR/dest/newdir/newdir2/          | DNE - dir/ | $DESTDIR/dest/newdir/newdir2/*/data.out          |
+| file7  | $DW_JOB_copyout-test/job/data.out     | file    | $DESTDIR/dest/newdir/newdir2/component | DNE - file | $DESTDIR/dest/newdir/newdir2/*/component         |
+| dir1   | $DW_JOB_copyout-test/job              | dir     | $DESTDIR/dest                          | dir        | $DESTDIR/dest/*/job/data.out                     |
+| dir2   | $DW_JOB_copyout-test/job/job2         | dir     | $DESTDIR/dest                          | dir        | $DESTDIR/dest/*/job2/data3.out                   |
+| dir3   | $DW_JOB_copyout-test/job              | dir     | $DESTDIR/dest/                         | dir/       | $DESTDIR/dest/*/job/data.out                     |
+| dir4   | $DW_JOB_copyout-test/job/             | dir/    | $DESTDIR/dest                          | dir        | $DESTDIR/dest/*/data.out                         |
+| dir5   | $DW_JOB_copyout-test/job/             | dir/    | $DESTDIR/dest/                         | dir/       | $DESTDIR/dest/*/data.out                         |
+| dir6   | $DW_JOB_copyout-test/job              | dir     | $DESTDIR/dest/newdir                   | DNE - dir  | $DESTDIR/dest/newdir/*/job/data.out              |
+| dir7   | $DW_JOB_copyout-test/job              | dir     | $DESTDIR/dest/newdir/                  | DNE - dir/ | $DESTDIR/dest/newdir/*/job/data.out              |
+| dir8   | $DW_JOB_copyout-test/job/             | dir/    | $DESTDIR/dest/newdir                   | DNE - dir  | $DESTDIR/dest/newdir/*/data.out                  |
+| dir9   | $DW_JOB_copyout-test/job/             | dir/    | $DESTDIR/dest/newdir/                  | DNE - dir/ | $DESTDIR/dest/newdir/*/data.out                  |
+| dir10  | $DW_JOB_copyout-test/job              | dir     | $DESTDIR/dest/newdir/newdir2           | DNE - dir  | $DESTDIR/dest/newdir/newdir2/*/job/data.out      |
+| dir11  | $DW_JOB_copyout-test/job              | dir     | $DESTDIR/dest/newdir/newdir2/          | DNE - dir/ | $DESTDIR/dest/newdir/newdir2/*/job/data.out      |
+| dir12  | $DW_JOB_copyout-test/job/             | dir/    | $DESTDIR/dest/newdir/newdir2           | DNE - dir  | $DESTDIR/dest/newdir/newdir2/*/data.out          |
+| dir13  | $DW_JOB_copyout-test/job/             | dir/    | $DESTDIR/dest/newdir/newdir2/          | DNE - dir/ | $DESTDIR/dest/newdir/newdir2/*/data.out          |
+| root1  | $DW_JOB_copyout-test                  | dir     | $DESTDIR/dest                          | dir        | $DESTDIR/dest/*/job/data.out                     |
+| root2  | $DW_JOB_copyout-test                  | dir     | $DESTDIR/dest/                         | dir/       | $DESTDIR/dest/*/job/data.out                     |
+| root3  | $DW_JOB_copyout-test/                 | dir/    | $DESTDIR/dest                          | dir        | $DESTDIR/dest/*/job/data.out                     |
+| root4  | $DW_JOB_copyout-test/                 | dir/    | $DESTDIR/dest/                         | dir/       | $DESTDIR/dest/*/job/data.out                     |
+| root5  | $DW_JOB_copyout-test                  | dir     | $DESTDIR/dest/newdir                   | dir        | $DESTDIR/dest/newdir/*/job/data.out              |
+| root6  | $DW_JOB_copyout-test                  | dir     | $DESTDIR/dest/newdir/                  | dir/       | $DESTDIR/dest/newdir/*/job/data.out              |
+| root7  | $DW_JOB_copyout-test/                 | dir/    | $DESTDIR/dest/newdir                   | dir        | $DESTDIR/dest/newdir/*/job/data.out              |
+| root8  | $DW_JOB_copyout-test/                 | dir/    | $DESTDIR/dest/newdir/                  | dir/       | $DESTDIR/dest/newdir/*/job/data.out              |

--- a/system-test/dm/test-copy-in-copy-out.sh
+++ b/system-test/dm/test-copy-in-copy-out.sh
@@ -37,16 +37,16 @@ pushd copy-in-copy-out
 python3 convert_table.py copy-in-copy-out.md copy-in-copy-out.json
 
 if [[ -n "${FS_TYPE}" ]]; then
-    ./copy-in-copy-out.bats
+    bats -j "${J}" -T ./copy-in-copy-out.bats
 else
     # Run copy_out tests for each filesystem
-    FS_TYPE=gfs2 ./copy-in-copy-out.bats
-    FS_TYPE=xfs ./copy-in-copy-out.bats
-    FS_TYPE=lustre ./copy-in-copy-out.bats
+    FS_TYPE=gfs2 bats -j "${J}" -T ./copy-in-copy-out.bats
+    FS_TYPE=xfs bats -j "${J}" -T ./copy-in-copy-out.bats
+    FS_TYPE=lustre bats -j "${J}" -T ./copy-in-copy-out.bats
 
     # Run the same with copy offload with supported filesystems (gfs2->lustre, lustre->lustre)
-    FS_TYPE=gfs2 COPY_OFFLOAD=y ./copy-in-copy-out.bats
-    FS_TYPE=lustre COPY_OFFLOAD=y ./copy-in-copy-out.bats
+    FS_TYPE=gfs2 COPY_OFFLOAD=y bats -j "${J}" -T ./copy-in-copy-out.bats
+    FS_TYPE=lustre COPY_OFFLOAD=y bats -j "${J}" -T ./copy-in-copy-out.bats
 fi
 
 popd


### PR DESCRIPTION
These test take a long time and there are a lot of them. Use unique
directories for each test so it can be ran in parallel.

Change the nightly test to take advantage of this and run 2 at a time
with 2 computes each.

Signed-off-by: Blake Devcich <blake.devcich@hpe.com>
