### PR TITLE
Add a crd-bumper.yaml

### DIFF
--- a/crd-bumper.yaml
+++ b/crd-bumper.yaml
@@ -1,0 +1,17 @@
+# A comma-separated list of directories where more Go code can be found, beyond
+# the usual cmd/, api/, internal/ that kubebuilder would put in place. The Go
+# files in these dirs will be bumped to the new hub version.
+extra_go_dirs: internal
+
+# A comma-separated list of pathnames to Go source files. These Go files will
+# be bumped to the new hub version. Use this when `extra_go_dirs` would be
+# too broad.
+extra_go_files: int_test.go,suite_test.go
+
+# The main file to look at to see how APIs are being imported. The default file
+# is cmd/main.go. Set this if a different file should be used.
+alternate_main: suite_test.go
+
+# Set this to true if this repo does not use controller-gen.
+skip_controller_gen: true
+


### PR DESCRIPTION
Add some hints so that vendor-new-api.py can understand this repo, because it doesn't look like other kubebuilder-based repos.