### PR TITLE
CRDBUMPER-vendor-new-api

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/NearNodeFlash/nnf-integration-test
 go 1.21
 
 require (
-	github.com/DataWorkflowServices/dws v0.0.1-0.20240916174522-9062a91241cd
+	github.com/DataWorkflowServices/dws v0.0.1-0.20241029172011-d5898d0b8640
 	github.com/onsi/ginkgo/v2 v2.17.1
 	github.com/onsi/gomega v1.32.0
 	go.openly.dev/pointy v1.3.0
@@ -17,7 +17,7 @@ require (
 require (
 	github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20240925185149-26d9d6071a1c
 	github.com/NearNodeFlash/nnf-ec v0.0.1-0.20241017152925-afc4d0cf1a4b // indirect
-	github.com/NearNodeFlash/nnf-sos v0.0.1-0.20241021195220-0cc1ba6de866
+	github.com/NearNodeFlash/nnf-sos v0.0.1-0.20241114160945-1b8980a4df2e
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,11 @@
-github.com/DataWorkflowServices/dws v0.0.1-0.20240916174522-9062a91241cd h1:/bSL8rV9cB13b3I5SCf20t4q3ab91i533sPcYIISI+8=
-github.com/DataWorkflowServices/dws v0.0.1-0.20240916174522-9062a91241cd/go.mod h1:6MrEEHISskyooSKcKU6R3mFqH6Yh6KzWgajhcw2s+nM=
+github.com/DataWorkflowServices/dws v0.0.1-0.20241029172011-d5898d0b8640 h1:JSjgesWkPo9sAc7QkjWisNDOlIOGR0MQX/hxXL56FTA=
+github.com/DataWorkflowServices/dws v0.0.1-0.20241029172011-d5898d0b8640/go.mod h1:6MrEEHISskyooSKcKU6R3mFqH6Yh6KzWgajhcw2s+nM=
 github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20240925185149-26d9d6071a1c h1:fSuMz3j8UzlYZI59Ded8XuUjYd7C5IyLB55jwgSTIew=
 github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20240925185149-26d9d6071a1c/go.mod h1:3wENUqk1b7V0q5L5kNQ2ZE3z/NywL4sqXqVYolsiJ94=
 github.com/NearNodeFlash/nnf-ec v0.0.1-0.20241017152925-afc4d0cf1a4b h1:Foz6dsOk49tPimuKOxHAijX2BPuLxLH3Z+IegBMKHsU=
 github.com/NearNodeFlash/nnf-ec v0.0.1-0.20241017152925-afc4d0cf1a4b/go.mod h1:oxdwMqfttOF9dabJhqrWlirCnMk8/8eyLMwl+hducjk=
-github.com/NearNodeFlash/nnf-sos v0.0.1-0.20241021195220-0cc1ba6de866 h1:iHjb4Et9En+qTt6Atryl9ekRvLusGZcPfemT4V7+yic=
-github.com/NearNodeFlash/nnf-sos v0.0.1-0.20241021195220-0cc1ba6de866/go.mod h1:TLmkLBd/iGosS1jIHxyJoSbcHC6DUwbAvREEJAaVvJk=
+github.com/NearNodeFlash/nnf-sos v0.0.1-0.20241114160945-1b8980a4df2e h1:q6ET0Gjp+2JExd6N1iAw7hmj8cuHE6UGwHt/iVcWq5M=
+github.com/NearNodeFlash/nnf-sos v0.0.1-0.20241114160945-1b8980a4df2e/go.mod h1:oV8wj0tG6qxlCbYWDsKuL+dLXQd6hNtxdyYsIjrMrBI=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=

--- a/internal/options.go
+++ b/internal/options.go
@@ -18,7 +18,7 @@ import (
 
 	dwsv1alpha2 "github.com/DataWorkflowServices/dws/api/v1alpha2"
 	lusv1alpha1 "github.com/NearNodeFlash/lustre-fs-operator/api/v1alpha1"
-	nnfv1alpha3 "github.com/NearNodeFlash/nnf-sos/api/v1alpha3"
+	nnfv1alpha4 "github.com/NearNodeFlash/nnf-sos/api/v1alpha4"
 
 	"github.com/DataWorkflowServices/dws/utils/dwdparse"
 )
@@ -293,7 +293,7 @@ func (t *T) Prepare(ctx context.Context, k8sClient client.Client) error {
 		By(fmt.Sprintf("Creating storage profile '%s'", o.storageProfile.name))
 
 		// Clone the default profile.
-		defaultProf := &nnfv1alpha3.NnfStorageProfile{
+		defaultProf := &nnfv1alpha4.NnfStorageProfile{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "default",
 				Namespace: "nnf-system",
@@ -302,7 +302,7 @@ func (t *T) Prepare(ctx context.Context, k8sClient client.Client) error {
 
 		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(defaultProf), defaultProf)).To(Succeed())
 
-		profile := &nnfv1alpha3.NnfStorageProfile{
+		profile := &nnfv1alpha4.NnfStorageProfile{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      o.storageProfile.name,
 				Namespace: "nnf-system",
@@ -326,7 +326,7 @@ func (t *T) Prepare(ctx context.Context, k8sClient client.Client) error {
 
 	if o.containerProfile != nil {
 		// Clone the provided base profile
-		baseProfile := &nnfv1alpha3.NnfContainerProfile{
+		baseProfile := &nnfv1alpha4.NnfContainerProfile{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      o.containerProfile.base,
 				Namespace: "nnf-system",
@@ -335,7 +335,7 @@ func (t *T) Prepare(ctx context.Context, k8sClient client.Client) error {
 
 		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(baseProfile), baseProfile)).To(Succeed())
 
-		profile := &nnfv1alpha3.NnfContainerProfile{
+		profile := &nnfv1alpha4.NnfContainerProfile{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      o.containerProfile.name,
 				Namespace: "nnf-system",
@@ -389,7 +389,7 @@ func (t *T) Prepare(ctx context.Context, k8sClient client.Client) error {
 
 		// Extract the File System Name and MGSNids from the persistent lustre instance. This
 		// assumes an NNF Storage resource is created in the same name as the persistent instance
-		storage := &nnfv1alpha3.NnfStorage{
+		storage := &nnfv1alpha4.NnfStorage{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: corev1.NamespaceDefault,
@@ -526,7 +526,7 @@ func (t *T) Cleanup(ctx context.Context, k8sClient client.Client) error {
 	if t.options.storageProfile != nil {
 		By(fmt.Sprintf("Deleting storage profile '%s'", o.storageProfile.name))
 
-		profile := &nnfv1alpha3.NnfStorageProfile{
+		profile := &nnfv1alpha4.NnfStorageProfile{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      o.storageProfile.name,
 				Namespace: "nnf-system",
@@ -540,7 +540,7 @@ func (t *T) Cleanup(ctx context.Context, k8sClient client.Client) error {
 	if t.options.containerProfile != nil {
 		By(fmt.Sprintf("Deleting container profile '%s'", o.containerProfile.name))
 
-		profile := &nnfv1alpha3.NnfContainerProfile{
+		profile := &nnfv1alpha4.NnfContainerProfile{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      o.containerProfile.name,
 				Namespace: "nnf-system",

--- a/suite_test.go
+++ b/suite_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+ * Copyright 2022-2024 Hewlett Packard Enterprise Development LP
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,
@@ -43,7 +43,7 @@ import (
 
 	dwsv1alpha2 "github.com/DataWorkflowServices/dws/api/v1alpha2"
 	lusv1alpha1 "github.com/NearNodeFlash/lustre-fs-operator/api/v1alpha1"
-	nnfv1alpha3 "github.com/NearNodeFlash/nnf-sos/api/v1alpha3"
+	nnfv1alpha4 "github.com/NearNodeFlash/nnf-sos/api/v1alpha4"
 )
 
 var (
@@ -113,7 +113,7 @@ var _ = BeforeSuite(func() {
 	err = lusv1alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = nnfv1alpha3.AddToScheme(scheme.Scheme)
+	err = nnfv1alpha4.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	By("Creating Client")


### PR DESCRIPTION
Vendor v1alpha4 API from github.com/NearNodeFlash/nnf-sos.

ACTION: If any of the code in this repo was referencing non-local
  APIs, the references to them may have been inadvertently
  modified. Verify that any non-local APIs are being referenced
  by their correct versions.

ACTION: Begin by running "make vet". Repair any issues that it finds.
  Then run "make test" and continue repairing issues until the tests
  pass.