### PR TITLE
system-test: Add capacity tests

### DIFF
--- a/.github/workflows/int-test.yaml
+++ b/.github/workflows/int-test.yaml
@@ -365,6 +365,7 @@ jobs:
           cd system-test
           touch env
           echo "GLOBAL_LUSTRE_ROOT?=/lus/global" >> env
+          echo "TEST_TMPDIR_PREFIX?=/nfs/imports/run/${USER}" >> env
           echo "DM_PROFILE?=no-xattr" >> env
           echo "N ?=4" >> env
           echo "J ?=1" >> env
@@ -397,6 +398,7 @@ jobs:
           cd system-test
           touch env
           echo "GLOBAL_LUSTRE_ROOT?=/lus/global" >> env
+          echo "TEST_TMPDIR_PREFIX?=/nfs/imports/run/${USER}" >> env
           echo "DM_PROFILE?=no-xattr" >> env
           echo "N ?=2" >> env
           echo "J ?=2" >> env

--- a/system-test/.gitignore
+++ b/system-test/.gitignore
@@ -2,3 +2,4 @@ bats/
 
 dm/copy-in-copy-out/copy-in-copy-out.json
 env
+tmp*

--- a/system-test/Makefile
+++ b/system-test/Makefile
@@ -52,7 +52,7 @@ DM_PROFILE ?=
 export DM_PROFILE
 
 # Default bats command
-BATS = bats -j $(J) -T
+BATS = bats -j $(J) -T --print-output-on-failure  --verbose-run
 
 .PHONY: all
 all: init test dm

--- a/system-test/dm/copy-in-copy-out/copy-in-copy-out.bats
+++ b/system-test/dm/copy-in-copy-out/copy-in-copy-out.bats
@@ -78,7 +78,7 @@ function setup() {
     # Make a unique directory to support simulteanous tests
     export UUID=$(uuidgen | cut -d'-' -f1)
     export DESTDIR=${TESTDIR}/${UUID}
-    mkdir ${DESTDIR}
+    mkdir -p ${DESTDIR}
     ./create-testfiles.sh ${DESTDIR}
 }
 

--- a/system-test/env.example
+++ b/system-test/env.example
@@ -9,6 +9,9 @@
 # Global Lustre Root Directory - used for data movement tests
 GLOBAL_LUSTRE_ROOT?=/lus/global
 
+# Test TEMPDIR Prefix. This must be available on the computes as well.
+TEST_TMPDIR_PREFIX?=/nfs/
+
 # Use 2 computes, 4 workflows in parallel using the flux queue `rabbit` and only on the two supplied compute nodes
 N?=2
 J?=4

--- a/system-test/system-test.bats
+++ b/system-test/system-test.bats
@@ -377,7 +377,7 @@ EOF
 @test "GFS2 - Capacity" {
     runit_file=$(create_capacity_file gfs2)
     ${FLUX_A} --setattr=dw="\
-        #DW jobdw type=xfs name=gfs2 capacity=${GB_PER_NODE}GB" \
+        #DW jobdw type=gfs2 name=gfs2 capacity=${GB_PER_NODE}GB" \
         $runit_file ${GB_PER_NODE} $CAPACITY_PERCENT
 }
 
@@ -385,6 +385,6 @@ EOF
 @test "Lustre - Capacity" {
     runit_file=$(create_capacity_file lustre)
     ${FLUX_A} --setattr=dw="\
-        #DW jobdw type=xfs name=lustre capacity=${LUS_CAPACITY}GB" \
+        #DW jobdw type=lustre name=lustre capacity=${LUS_CAPACITY}GB" \
         $runit_file ${LUS_CAPACITY} $CAPACITY_PERCENT
 }

--- a/system-test/system-test.bats
+++ b/system-test/system-test.bats
@@ -23,6 +23,11 @@ if [[ -z "${GLOBAL_LUSTRE_ROOT}" ]]; then
     GLOBAL_LUSTRE_ROOT=/lus/global
 fi
 
+# Test Tempdir directory
+if [[ -z "${TEST_TMPDIR_PREFIX}" ]]; then
+    TEST_TMPDIR_PREFIX=${HOME}/nnf/tmp
+fi
+
 # Number of compute nodes; default to 4
 if [[ -z "${N}" ]]; then
     N=4
@@ -30,15 +35,18 @@ fi
 
 # Flux command
 FLUX="flux run -l -N${N} --wait-event=clean"
+FLUX_A="flux alloc -N${N}"
 
 # Use a Flux queue
 if [ "${Q}" != "" ]; then
     FLUX+=" -q ${Q}"
+    FLUX_A+=" -q ${Q}"
 fi
 
 # Require specific rabbits
 if [ "${R}" != "" ]; then
     FLUX+=" --requires=hosts:${R}"
+    FLUX_A+=" --requires=hosts:${R}"
 fi
 
 # Command to run on the compute node via flux
@@ -46,7 +54,11 @@ fi
 #COMPUTE_CMD="bash -c 'hostname'"
 COMPUTE_CMD='hostname'
 
-GB_PER_NODE=100
+# How much space to request for rabbit workflows per node
+GB_PER_NODE=300
+
+# For capacity tests, what is the threshold of available capacity vs the requested capacity
+CAPACITY_PERCENT=80
 
 function setup_file {
     # When using UUID in the DW name keyboard, just use the first 9 digits to make $DW_ env vars easier
@@ -54,6 +66,20 @@ function setup_file {
 
     # For lustre tests, use the total capacity given the node count
     export LUS_CAPACITY=$(($N * $GB_PER_NODE))
+
+    # Ensure tempdir prefix directory exists
+    mkdir -p ${TEST_TMPDIR_PREFIX}
+}
+
+function setup {
+    # Create a test tmpdir at the supplied prefix (e.g. /home/user/nnf/tmp.x8e8f0a/)
+    export TEST_TMPDIR=$(mktemp -d -p ${TEST_TMPDIR_PREFIX})
+}
+
+function teardown {
+    if [[ -n "$TEST_TMPDIR" ]]; then
+        rm -rf $TEST_TMPDIR
+    fi
 }
 
 #----------------------------------------------------------
@@ -293,4 +319,72 @@ function setup_file {
     ${FLUX} --setattr=dw="\
         #DW destroy_persistent name=persistent-raw-${UUID}" \
         ${COMPUTE_CMD}
+}
+
+#----------------------------------------------------------
+# Capacity Tests
+#----------------------------------------------------------
+function create_capacity_file {
+    wf_name=$1
+    runit_file="$TEST_TMPDIR/run-it.sh"
+    touch $runit_file
+    chmod +x $runit_file
+    cat << 'EOF' >> $runit_file
+#!/bin/bash
+echo "jobid: $(flux getattr jobid)"
+requested_size=$1
+capacity_percent=$2
+
+echo "\$DW_JOB_<NAME>: $DW_JOB_<NAME>"
+
+df_output=$(flux run -N1 df -BG "$DW_JOB_<NAME>" 2>/dev/null | tail -1)
+if [ -z "$df_output" ]; then
+    echo "Error: Invalid filesystem path or unable to retrieve information."
+    exit 1
+fi
+
+available_size=$(echo "$df_output" | awk '{print $2}' | sed 's/G//')
+required_size=$(( requested_size * capacity_percent / 100 ))
+
+echo "requested_size: ${requested_size} GB"
+echo "required_size (${capacity_percent}%): ${required_size} GB"
+echo "available_size: ${available_size} GB"
+
+if [ "$available_size" -ge "$required_size" ]; then
+    echo "Sufficient space available: ${available_size}G (>= ${capacity_percent}% of ${requested_size}G)"
+    exit 0
+else
+    echo "Insufficient space: ${available_size}G (< ${capacity_percent}% of ${requested_size}G)"
+    exit 1
+fi
+EOF
+
+    # replace the workflow name in the $DW_JOB_ env var
+    sed -i "s/<NAME>/$wf_name/g" $runit_file
+
+    echo $runit_file
+}
+
+# bats test_tags=tag:xfs, tag:capacity
+@test "XFS - Capacity" {
+    runit_file=$(create_capacity_file xfs)
+    ${FLUX_A} --setattr=dw="\
+        #DW jobdw type=xfs name=xfs capacity=${GB_PER_NODE}GB" \
+        $runit_file ${GB_PER_NODE} $CAPACITY_PERCENT
+}
+
+# bats test_tags=tag:gfs2, tag:capacity
+@test "GFS2 - Capacity" {
+    runit_file=$(create_capacity_file gfs2)
+    ${FLUX_A} --setattr=dw="\
+        #DW jobdw type=xfs name=gfs2 capacity=${GB_PER_NODE}GB" \
+        $runit_file ${GB_PER_NODE} $CAPACITY_PERCENT
+}
+
+# bats test_tags=tag:lustre, tag:capacity
+@test "Lustre - Capacity" {
+    runit_file=$(create_capacity_file lustre)
+    ${FLUX_A} --setattr=dw="\
+        #DW jobdw type=xfs name=lustre capacity=${LUS_CAPACITY}GB" \
+        $runit_file ${LUS_CAPACITY} $CAPACITY_PERCENT
 }


### PR DESCRIPTION
This adds capacity test to ensure that 80% of the requested capacity is
available on the provided filesystem.

To support this, test scripts must be used to submit to flux alloc. A
temp directory is now created for each test to ensure a safe place to
put the test script. This directory must reside in a location is that
available on the compute nodes.

The root of the directory can be set with `TEST_TMPDIR_PREFIX` and
defaults to `${HOME}/nnf/tmp`.

Signed-off-by: Blake Devcich <blake.devcich@hpe.com>