### PR TITLE
CRDBUMPER-vendor-new-api

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,8 +16,8 @@ require (
 
 require (
 	github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20241209183639-2d8fdbd63dec
-	github.com/NearNodeFlash/nnf-ec v0.0.1-0.20241205165035-51a536434b0d // indirect
-	github.com/NearNodeFlash/nnf-sos v0.0.1-0.20241211170601-b6a1ac55c9e4
+	github.com/NearNodeFlash/nnf-ec v0.0.1-0.20250113163425-2fd0825bc67c // indirect
+	github.com/NearNodeFlash/nnf-sos v0.0.1-0.20250129201741-d53005cfce87
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -2,10 +2,10 @@ github.com/DataWorkflowServices/dws v0.0.1-0.20241029172011-d5898d0b8640 h1:JSjg
 github.com/DataWorkflowServices/dws v0.0.1-0.20241029172011-d5898d0b8640/go.mod h1:6MrEEHISskyooSKcKU6R3mFqH6Yh6KzWgajhcw2s+nM=
 github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20241209183639-2d8fdbd63dec h1:LPeWeG5xeqixm1YfE26jY5mbhFS8jNkErrI+WmQLFgg=
 github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20241209183639-2d8fdbd63dec/go.mod h1:3JGfBMIfipAZbbAAesSvKzGmKGAh2Wu6pPGQWMP2f8w=
-github.com/NearNodeFlash/nnf-ec v0.0.1-0.20241205165035-51a536434b0d h1:s+zaQp8959Z1KjAo/zRP05CRJUrHTKx2ItbR4C3ffQw=
-github.com/NearNodeFlash/nnf-ec v0.0.1-0.20241205165035-51a536434b0d/go.mod h1:oxdwMqfttOF9dabJhqrWlirCnMk8/8eyLMwl+hducjk=
-github.com/NearNodeFlash/nnf-sos v0.0.1-0.20241211170601-b6a1ac55c9e4 h1:+koOgtNA8cXyIjiHOvqTxOGFgFtJiT2p3nZ3718mGk4=
-github.com/NearNodeFlash/nnf-sos v0.0.1-0.20241211170601-b6a1ac55c9e4/go.mod h1:5wXbwDIublnrX22FCHB26PBxMOPY1J78lFh3LBY/vRE=
+github.com/NearNodeFlash/nnf-ec v0.0.1-0.20250113163425-2fd0825bc67c h1:zK1VlTmgsa+dhbLWOGaQ1GWyFeyv8jQmkiVq27VzGNc=
+github.com/NearNodeFlash/nnf-ec v0.0.1-0.20250113163425-2fd0825bc67c/go.mod h1:oxdwMqfttOF9dabJhqrWlirCnMk8/8eyLMwl+hducjk=
+github.com/NearNodeFlash/nnf-sos v0.0.1-0.20250129201741-d53005cfce87 h1:m7LgiHBBrIfS/VkLFC45oVe+Z7um+23lnNVG2PZf1OA=
+github.com/NearNodeFlash/nnf-sos v0.0.1-0.20250129201741-d53005cfce87/go.mod h1:bm0iof23Wxa16sFnPquJFT/rAakEBdLR95obhUdZ95M=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=

--- a/internal/options.go
+++ b/internal/options.go
@@ -18,7 +18,7 @@ import (
 
 	dwsv1alpha2 "github.com/DataWorkflowServices/dws/api/v1alpha2"
 	lusv1alpha1 "github.com/NearNodeFlash/lustre-fs-operator/api/v1alpha1"
-	nnfv1alpha4 "github.com/NearNodeFlash/nnf-sos/api/v1alpha4"
+	nnfv1alpha5 "github.com/NearNodeFlash/nnf-sos/api/v1alpha5"
 
 	"github.com/DataWorkflowServices/dws/utils/dwdparse"
 )
@@ -293,7 +293,7 @@ func (t *T) Prepare(ctx context.Context, k8sClient client.Client) error {
 		By(fmt.Sprintf("Creating storage profile '%s'", o.storageProfile.name))
 
 		// Clone the default profile.
-		defaultProf := &nnfv1alpha4.NnfStorageProfile{
+		defaultProf := &nnfv1alpha5.NnfStorageProfile{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "default",
 				Namespace: "nnf-system",
@@ -302,7 +302,7 @@ func (t *T) Prepare(ctx context.Context, k8sClient client.Client) error {
 
 		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(defaultProf), defaultProf)).To(Succeed())
 
-		profile := &nnfv1alpha4.NnfStorageProfile{
+		profile := &nnfv1alpha5.NnfStorageProfile{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      o.storageProfile.name,
 				Namespace: "nnf-system",
@@ -326,7 +326,7 @@ func (t *T) Prepare(ctx context.Context, k8sClient client.Client) error {
 
 	if o.containerProfile != nil {
 		// Clone the provided base profile
-		baseProfile := &nnfv1alpha4.NnfContainerProfile{
+		baseProfile := &nnfv1alpha5.NnfContainerProfile{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      o.containerProfile.base,
 				Namespace: "nnf-system",
@@ -335,7 +335,7 @@ func (t *T) Prepare(ctx context.Context, k8sClient client.Client) error {
 
 		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(baseProfile), baseProfile)).To(Succeed())
 
-		profile := &nnfv1alpha4.NnfContainerProfile{
+		profile := &nnfv1alpha5.NnfContainerProfile{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      o.containerProfile.name,
 				Namespace: "nnf-system",
@@ -389,7 +389,7 @@ func (t *T) Prepare(ctx context.Context, k8sClient client.Client) error {
 
 		// Extract the File System Name and MGSNids from the persistent lustre instance. This
 		// assumes an NNF Storage resource is created in the same name as the persistent instance
-		storage := &nnfv1alpha4.NnfStorage{
+		storage := &nnfv1alpha5.NnfStorage{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: corev1.NamespaceDefault,
@@ -526,7 +526,7 @@ func (t *T) Cleanup(ctx context.Context, k8sClient client.Client) error {
 	if t.options.storageProfile != nil {
 		By(fmt.Sprintf("Deleting storage profile '%s'", o.storageProfile.name))
 
-		profile := &nnfv1alpha4.NnfStorageProfile{
+		profile := &nnfv1alpha5.NnfStorageProfile{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      o.storageProfile.name,
 				Namespace: "nnf-system",
@@ -540,7 +540,7 @@ func (t *T) Cleanup(ctx context.Context, k8sClient client.Client) error {
 	if t.options.containerProfile != nil {
 		By(fmt.Sprintf("Deleting container profile '%s'", o.containerProfile.name))
 
-		profile := &nnfv1alpha4.NnfContainerProfile{
+		profile := &nnfv1alpha5.NnfContainerProfile{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      o.containerProfile.name,
 				Namespace: "nnf-system",

--- a/suite_test.go
+++ b/suite_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 Hewlett Packard Enterprise Development LP
+ * Copyright 2022-2025 Hewlett Packard Enterprise Development LP
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,
@@ -43,7 +43,7 @@ import (
 
 	dwsv1alpha2 "github.com/DataWorkflowServices/dws/api/v1alpha2"
 	lusv1alpha1 "github.com/NearNodeFlash/lustre-fs-operator/api/v1alpha1"
-	nnfv1alpha4 "github.com/NearNodeFlash/nnf-sos/api/v1alpha4"
+	nnfv1alpha5 "github.com/NearNodeFlash/nnf-sos/api/v1alpha5"
 )
 
 var (
@@ -113,7 +113,7 @@ var _ = BeforeSuite(func() {
 	err = lusv1alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = nnfv1alpha4.AddToScheme(scheme.Scheme)
+	err = nnfv1alpha5.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	By("Creating Client")


### PR DESCRIPTION
Vendor v1alpha5 API from github.com/NearNodeFlash/nnf-sos.

ACTION: If any of the code in this repo was referencing non-local
  APIs, the references to them may have been inadvertently
  modified. Verify that any non-local APIs are being referenced
  by their correct versions.

ACTION: Begin by running "make vet". Repair any issues that it finds.
  Then run "make test" and continue repairing issues until the tests
  pass.