### PR TITLE
CRDBUMPER-vendor-new-api

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/DataWorkflowServices/dws v0.0.1-0.20250610194327-bc91fef8e840
 	github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20250708135942-4a4d148d7772
 	github.com/NearNodeFlash/nnf-ec v0.0.1-0.20250702200322-db4e4089d5e0 // indirect
-	github.com/NearNodeFlash/nnf-sos v0.0.1-0.20250708141732-79259d489832
+	github.com/NearNodeFlash/nnf-sos v0.0.1-0.20250716194043-7f8e1465752c
 	github.com/onsi/ginkgo/v2 v2.22.2
 	github.com/onsi/gomega v1.36.2
 	go.openly.dev/pointy v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20250708135942-4a4d148d7772
 github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20250708135942-4a4d148d7772/go.mod h1:Hzd47Ti0pzNB44yeWgDDdNuRqfWFDkJNbMLEXwtjEyE=
 github.com/NearNodeFlash/nnf-ec v0.0.1-0.20250702200322-db4e4089d5e0 h1:meUKolZ546eXAfReA4ZxS+s1D9Rek4IuKfyT00mr1dw=
 github.com/NearNodeFlash/nnf-ec v0.0.1-0.20250702200322-db4e4089d5e0/go.mod h1:lx13ustzE/+39fLECky+CFKkAV8GYlX9eaI6IGmHQkY=
-github.com/NearNodeFlash/nnf-sos v0.0.1-0.20250708141732-79259d489832 h1:eAvmmB/FkzGwdaLxOBONC2WJ9VSYz2cHsfOK8QuAzh0=
-github.com/NearNodeFlash/nnf-sos v0.0.1-0.20250708141732-79259d489832/go.mod h1:f5duBSZaTrkf3fIksVxLXXTAW9rpziK6aMBn7RNFm/M=
+github.com/NearNodeFlash/nnf-sos v0.0.1-0.20250716194043-7f8e1465752c h1:hKeodo0YG+pKmdpRie7XyanE8tO8N5VYR6upD0+8urg=
+github.com/NearNodeFlash/nnf-sos v0.0.1-0.20250716194043-7f8e1465752c/go.mod h1:f5duBSZaTrkf3fIksVxLXXTAW9rpziK6aMBn7RNFm/M=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=

--- a/internal/options.go
+++ b/internal/options.go
@@ -37,7 +37,7 @@ import (
 
 	dwsv1alpha4 "github.com/DataWorkflowServices/dws/api/v1alpha4"
 	lusv1alpha1 "github.com/NearNodeFlash/lustre-fs-operator/api/v1alpha1"
-	nnfv1alpha7 "github.com/NearNodeFlash/nnf-sos/api/v1alpha7"
+	nnfv1alpha8 "github.com/NearNodeFlash/nnf-sos/api/v1alpha8"
 
 	"github.com/DataWorkflowServices/dws/utils/dwdparse"
 )
@@ -312,7 +312,7 @@ func (t *T) Prepare(ctx context.Context, k8sClient client.Client) error {
 		By(fmt.Sprintf("Creating storage profile '%s'", o.storageProfile.name))
 
 		// Clone the default profile.
-		defaultProf := &nnfv1alpha7.NnfStorageProfile{
+		defaultProf := &nnfv1alpha8.NnfStorageProfile{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "default",
 				Namespace: "nnf-system",
@@ -321,7 +321,7 @@ func (t *T) Prepare(ctx context.Context, k8sClient client.Client) error {
 
 		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(defaultProf), defaultProf)).To(Succeed())
 
-		profile := &nnfv1alpha7.NnfStorageProfile{
+		profile := &nnfv1alpha8.NnfStorageProfile{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      o.storageProfile.name,
 				Namespace: "nnf-system",
@@ -345,7 +345,7 @@ func (t *T) Prepare(ctx context.Context, k8sClient client.Client) error {
 
 	if o.containerProfile != nil {
 		// Clone the provided base profile
-		baseProfile := &nnfv1alpha7.NnfContainerProfile{
+		baseProfile := &nnfv1alpha8.NnfContainerProfile{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      o.containerProfile.base,
 				Namespace: "nnf-system",
@@ -354,7 +354,7 @@ func (t *T) Prepare(ctx context.Context, k8sClient client.Client) error {
 
 		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(baseProfile), baseProfile)).To(Succeed())
 
-		profile := &nnfv1alpha7.NnfContainerProfile{
+		profile := &nnfv1alpha8.NnfContainerProfile{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      o.containerProfile.name,
 				Namespace: "nnf-system",
@@ -408,7 +408,7 @@ func (t *T) Prepare(ctx context.Context, k8sClient client.Client) error {
 
 		// Extract the File System Name and MGSNids from the persistent lustre instance. This
 		// assumes an NNF Storage resource is created in the same name as the persistent instance
-		storage := &nnfv1alpha7.NnfStorage{
+		storage := &nnfv1alpha8.NnfStorage{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: corev1.NamespaceDefault,
@@ -545,7 +545,7 @@ func (t *T) Cleanup(ctx context.Context, k8sClient client.Client) error {
 	if t.options.storageProfile != nil {
 		By(fmt.Sprintf("Deleting storage profile '%s'", o.storageProfile.name))
 
-		profile := &nnfv1alpha7.NnfStorageProfile{
+		profile := &nnfv1alpha8.NnfStorageProfile{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      o.storageProfile.name,
 				Namespace: "nnf-system",
@@ -559,7 +559,7 @@ func (t *T) Cleanup(ctx context.Context, k8sClient client.Client) error {
 	if t.options.containerProfile != nil {
 		By(fmt.Sprintf("Deleting container profile '%s'", o.containerProfile.name))
 
-		profile := &nnfv1alpha7.NnfContainerProfile{
+		profile := &nnfv1alpha8.NnfContainerProfile{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      o.containerProfile.name,
 				Namespace: "nnf-system",

--- a/suite_test.go
+++ b/suite_test.go
@@ -43,7 +43,7 @@ import (
 
 	dwsv1alpha4 "github.com/DataWorkflowServices/dws/api/v1alpha4"
 	lusv1alpha1 "github.com/NearNodeFlash/lustre-fs-operator/api/v1alpha1"
-	nnfv1alpha7 "github.com/NearNodeFlash/nnf-sos/api/v1alpha7"
+	nnfv1alpha8 "github.com/NearNodeFlash/nnf-sos/api/v1alpha8"
 )
 
 var (
@@ -113,7 +113,7 @@ var _ = BeforeSuite(func() {
 	err = lusv1alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = nnfv1alpha7.AddToScheme(scheme.Scheme)
+	err = nnfv1alpha8.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	By("Creating Client")


### PR DESCRIPTION
Vendor v1alpha8 API from github.com/NearNodeFlash/nnf-sos.

ACTION: If any of the code in this repo was referencing non-local
  APIs, the references to them may have been inadvertently
  modified. Verify that any non-local APIs are being referenced
  by their correct versions.

ACTION: Begin by running "make vet". Repair any issues that it finds.
  Then run "make test" and continue repairing issues until the tests
  pass.