### PR TITLE
Allow XFS:lvCreate command to be specified

### DIFF
--- a/int_test.go
+++ b/int_test.go
@@ -57,7 +57,7 @@ var tests = []*T{
 	//   MakeTest("Pending", "#DW ...").Pending()
 	//
 	// Mark a test case so it will stop after the workflow achieves the desired state of PreRun
-	//   MakeTest("Stop After", "#DW ...").StopAfter(wsv1alpha1.StatePreRun),
+	//   MakeTest("Stop After", "#DW ...").StopAfter(dwsv1alpha6.StatePreRun),
 	//
 	// Duplicate a test case 20 times.
 	//   DuplicateTest(
@@ -80,6 +80,10 @@ var tests = []*T{
 	MakeTest("GFS2 with Storage Profile",
 		"#DW jobdw type=gfs2 name=gfs2-storage-profile capacity=50GB profile=my-gfs2-storage-profile").
 		WithStorageProfile(),
+	MakeTest("XFS with Storage Profile and LV Create",
+		"#DW jobdw type=xfs name=xfs-storage-profile capacity=14TB profile=my-xfs-storage-profile").
+		WithStorageProfileLvCreate("--zero n --activate y --type raid5 --nosync --extents $PERCENT_VG --stripes $DEVICE_NUM-1 --stripesize=64KiB --name $LV_NAME $VG_NAME"),
+
 
 	// Persistent
 	MakeTest("Persistent Lustre",

--- a/internal/options.go
+++ b/internal/options.go
@@ -99,9 +99,10 @@ type TStorageProfile struct {
 	name          string
 	externalMgs   string
 	standaloneMgt string
+	lvCreateCmd   string
 }
 
-// WithStorageProfile will manage a storage profile of of name 'name'
+// WithStorageProfile will manage a storage profile of name 'name'
 func (t *T) WithStorageProfile() *T {
 
 	for _, directive := range t.directives {
@@ -130,6 +131,13 @@ func (t *T) WithStorageProfileExternalMGS(externalMGS string) *T {
 	t.options.storageProfile.externalMgs = externalMGS
 
 	return t.WithLabels("externalMGS")
+}
+
+func (t *T) WithStorageProfileLvCreate(lvCreateCmd string) *T {
+	t.WithStorageProfile()
+	t.options.storageProfile.lvCreateCmd = lvCreateCmd
+
+	return t.WithLabels("lvCreateCmd")
 }
 
 // WithExternalComputes engages external computes for the the test.
@@ -338,6 +346,10 @@ func (t *T) Prepare(ctx context.Context, k8sClient client.Client) error {
 			profile.Data.LustreStorage.CombinedMGTMDT = false
 			profile.Data.LustreStorage.ExternalMGS = ""
 			profile.Data.LustreStorage.StandaloneMGTPoolName = o.storageProfile.standaloneMgt
+		}
+
+		if o.storageProfile.lvCreateCmd != "" {
+			profile.Data.XFSStorage.CmdLines.LvCreate = o.storageProfile.lvCreateCmd
 		}
 
 		Expect(k8sClient.Create(ctx, profile)).To(Succeed())


### PR DESCRIPTION
Add the capability to specify the lvCreate command for a storage profile.