### PR TITLE
Add kind cluster support: auto-detect kind and skip incompatible tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ endif
 export PATH := $(HOME)/go/bin:$(PATH)
 
 # Base command to start the tests with ginkgo
-GINKGO_RUN?=CGO_ENABLED=0 ginkgo run ${PARALLEL_OPT} --v
+GINKGO_RUN?=CGO_ENABLED=0 ginkgo run ${PARALLEL_OPT} --v --fail-fast
 
 all: fmt vet
 
@@ -22,9 +22,19 @@ vet:
 	go vet ./...
 
 # TODO: would be nice to tie this to a script that also deletes all the workflows and makes sure nothing is left over
+# Clean up resources that may be left behind by interrupted test runs
 .PHONY: clean
 clean:
+	@echo "Removing triage namespace..."
 	kubectl delete namespace nnf-system-needs-triage --ignore-not-found
+	@echo "Removing leftover UID verification pods..."
+	kubectl delete pods -n default --ignore-not-found $$(kubectl get pods -n default --no-headers -o custom-columns=':metadata.name' 2>/dev/null | grep '^verify-uid-') 2>/dev/null; true
+	@echo "Checking for persistent storage instances..."
+	@psi=$$(kubectl get persistentstorageinstances -A --no-headers 2>/dev/null); \
+	if [ -n "$$psi" ]; then \
+		echo "WARNING: Persistent storage instances still exist. These require a destroy_persistent workflow to remove:" >&2; \
+		echo "$$psi" >&2; \
+	fi
 
 .PHONY: init
 init:
@@ -33,11 +43,21 @@ init:
 # Run all the tests
 .PHONY: test
 test:
-	${GINKGO_RUN} .
+	@if kubectl config current-context 2>/dev/null | grep -q 'kind-'; then \
+		echo "Detected kind cluster. Switching to 'make kind' (excludes global-lustre tests)." >&2; \
+		$(MAKE) kind; \
+	else \
+		${GINKGO_RUN} . ; \
+	fi
 
 # Alias for all the tests
 .PHONY: full
 full: test
+
+# Run tests compatible with a kind environment (excludes tests requiring real Lustre mounts)
+.PHONY: kind
+kind:
+	${GINKGO_RUN} --label-filter='!global-lustre && !multi-storage && !lustre-csimount && !high-capacity' .
 
 # Run one test to ensure system is in working order
 .PHONY: sanity

--- a/int_test.go
+++ b/int_test.go
@@ -102,7 +102,8 @@ var tests = []*T{
 	// WithStorageProfile().DelayInState(dwsv1alpha7.StateDataIn, 15*time.Second).StopAfter(dwsv1alpha7.StatePreRun).Focused(),
 	MakeTest("XFS with Storage Profile and LV Create",
 		"#DW jobdw type=xfs name=xfs-storage-profile capacity=14TB profile=my-xfs-storage-profile").
-		WithStorageProfileLvCreate("--zero n --activate y --type raid5 --nosync --extents $PERCENT_VG --stripes $DEVICE_NUM-1 --stripesize=64KiB --name $LV_NAME $VG_NAME"),
+		WithStorageProfileLvCreate("--zero n --activate y --type raid5 --nosync --extents $PERCENT_VG --stripes $DEVICE_NUM-1 --stripesize=64KiB --name $LV_NAME $VG_NAME").
+		WithLabels("high-capacity"),
 
 	// Persistent
 	MakeTest("Persistent Lustre",
@@ -150,7 +151,7 @@ var tests = []*T{
 		"#DW jobdw type=lustre name=lustre-with-containers-mpi capacity=100GB",
 		"#DW container name=lustre-with-containers-mpi profile=example-mpi "+
 			"DW_JOB_foo_local_storage=lustre-with-containers-mpi").
-		WithPermissions(userID, groupID).WithLabels("mpi"),
+		WithPermissions(userID, groupID).WithLabels("mpi", "lustre-csimount"),
 	MakeTest("GFS2 and Global Lustre with MPI Containers",
 		"#DW jobdw type=gfs2 name=gfs2-and-global-with-containers-mpi capacity=100GB",
 		"#DW container name=gfs2-and-global-with-containers-mpi profile=example-mpi "+
@@ -217,7 +218,7 @@ var tests = []*T{
 		WithContainerProfile("example-fail", &ContainerProfileOptions{RetryLimit: pointy.Int(0)}).
 		ExpectError(dwsv1alpha7.StatePostRun),
 
-	// Containers - Unsupported Filesystems. These should fail as xfs/raw filesystems are not supported for containers.
+	// Containers - Unsupported Filesystems. XFS is not supported for containers.
 	MakeTest("XFS with Containers",
 		"#DW jobdw type=xfs name=xfs-with-containers capacity=100GB",
 		"#DW container name=xfs-with-containers profile=example-success DW_JOB_foo_local_storage=xfs-with-containers").
@@ -225,7 +226,7 @@ var tests = []*T{
 	MakeTest("Raw with Containers",
 		"#DW jobdw type=raw name=raw-with-containers capacity=100GB",
 		"#DW container name=raw-with-containers profile=example-success DW_JOB_foo_local_storage=raw-with-containers").
-		ExpectError(dwsv1alpha7.StateProposal).WithLabels("unsupported-fs"),
+		WithPermissions(userID, groupID).WithLabels("non-mpi"),
 
 	// Containers - Multiple Storages
 	MakeTest("GFS2 and Lustre with Containers",


### PR DESCRIPTION
- Add `make kind` target that excludes tests requiring real Lustre CSI mounts (global-lustre, multi-storage, lustre-csimount) or high NVMe capacity (high-capacity)
- Auto-detect kind cluster in `make test` and delegate to `make kind`
- Add --fail-fast to default ginkgo flags
- Improve `make clean`: remove stale verify-uid pods, warn about lingering persistent storage instances
- Update Raw with Containers test: raw is now allowed with containers

Signed-off-by: Anthony Floeder <anthony.floeder@hpe.com>